### PR TITLE
m8-common: Allow media UID process to access CameraServiceProxy

### DIFF
--- a/m8-common.mk
+++ b/m8-common.mk
@@ -25,7 +25,8 @@ $(call inherit-product, device/htc/msm8974-common/msm8974-common.mk)
 
 # Overlay
 DEVICE_PACKAGE_OVERLAYS += \
-    $(LOCAL_PATH)/overlay
+    $(LOCAL_PATH)/overlay \
+    $(LOCAL_PATH)/overlay-lineage
 
 # Permissions
 PRODUCT_COPY_FILES += \

--- a/overlay-lineage/frameworks/base/core/res/res/values/config.xml
+++ b/overlay-lineage/frameworks/base/core/res/res/values/config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Whether to allow process with media UID to access CameraServiceProxy -->
+    <bool name="config_allowMediaUidForCameraServiceProxy">true</bool>
+</resources>


### PR DESCRIPTION
 * This fixes the following error on camera-in-mediaserver devices:

   E CameraService_proxy: Calling UID: 1013 doesn't match expected  camera service UID!

Change-Id: I185e34e8983b286436bfc0fe36cfdf260ef78170